### PR TITLE
Fix call to `login` method in `register` function tests

### DIFF
--- a/my_custom_templates/KindeClient.spec.js
+++ b/my_custom_templates/KindeClient.spec.js
@@ -141,7 +141,7 @@ import sinon from 'sinon';
         req.query = { post_login_redirect_url: '/post-login-url' };
         req.headers.cookie = `kindeSessionId=${sessionId}`;
         KindeManagementApi.SessionStore.setData(sessionId, {});
-        await instance.login()(req, res, next);
+        await instance.register()(req, res, next);
         const cachedPostLoginParam = KindeManagementApi.SessionStore.getDataByKey(sessionId, 'kindePostLoginRedirectUrl');
         expect(cachedPostLoginParam).to.be(req.query.post_login_redirect_url);
       });

--- a/my_custom_templates/SessionStore.js
+++ b/my_custom_templates/SessionStore.js
@@ -43,6 +43,17 @@ const createSessionStore = () => {
   };
 
   /**
+   * Remove data in the session store for a specific sessionId and key.
+   * @param {string} sessionId - The session ID.
+   * @param {string} key - The key to store the data.
+   */
+  const removeDataByKey = (sessionId, key) => {
+    if (store[sessionId] && store[sessionId][key]) {
+      delete store[sessionId][key];
+    }
+  }
+
+  /**
    * Remove data from the session store for a specific sessionId.
    * @param {string} sessionId - The session ID.
    */
@@ -57,6 +68,7 @@ const createSessionStore = () => {
     setData,
     getDataByKey,
     setDataByKey,
+    removeDataByKey,
     removeData,
   };
 };


### PR DESCRIPTION
# Explain your changes

In addition to rectifying the problem mentioned in [here](), this pull request also updates the `SessionStore.js` file with the one in the SDK repo (this one is missing the `removeDataByKey` method). This was missed in the [earlier](https://github.com/kinde-oss/kinde-nodejs-generator/pull/13) PR.

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
